### PR TITLE
missing mtproto client

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
   - [Bot Libraries](#bot-libraries)
   - [Clients](#clients)
   - [MTProto implementations](#mtproto-implementations)
+  - [TDLib implementations](#tdlib-implementations)
   - [Schemas](#schemas)
   - [MTProto Proxy](#mtproto-proxy)
   - [Misc](#misc)
@@ -68,7 +69,7 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 * [TelegramTUI](https://github.com/bad-day/TelegramTUI) - Telegram client on your console
 
 ## MTProto implementations
-* [Airgram](https://github.com/airgram/airgram) - `TypeScript/JavaScript` modern Telegram Client Framework
+* [Airgram](https://github.com/airgram/airgram/tree/mtproto) - `TypeScript/JavaScript` modern Telegram Client Framework
 * [Kotlogram](https://github.com/badoualy/kotlogram) - `Java/Kotlin`
 * [MadelineProto](https://github.com/danog/MadelineProto) - `PHP`
 * [mtproto2json](https://github.com/nikat/mtproto2json) - `Python` MTProto/JSON proxy server
@@ -80,8 +81,10 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 * [TL-Elixir](https://gitlab.com/snippets/1664390) - `Elixir`
 * [Vail](https://github.com/JuanPotato/Vail) - `Rust`
 
-## Schemas
+## TDLib implementations
+* [Airgram](https://github.com/airgram/airgram) - `TypeScript/JavaScript` modern TDLib Client Framework
 
+## Schemas
 * [Bot API Schema](https://github.com/tranql/telegram-bot-api-schema) - Bot API schema
 * [TL-Schema](https://github.com/stek29/tl-schema) - TL MTProto schema
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 * [telegram-bot-rust](https://github.com/telegram-rs/telegram-bot) - `Rust`
 * [telegram-bot-swift](https://github.com/zmeyc/telegram-bot-swift) - `Swift` Telegram Bot SDK for Swift (unofficial)
 * [telegram-node-bot](https://github.com/Naltox/telegram-node-bot) - `JavaScript` Node module for creating Telegram bots
+* [telegram.bot](https://github.com/TelegramBots/telegram.bot) - `C#` .NET Client for Telegram Bot API
 * [x86_64-asm-tgbot](https://github.com/StefanoBelli/x86_64-asm-tgbot) - `x86_64 assembly`
 
 ## Clients

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 * [TReact](https://github.com/goodmind/treact) - ReactJS frontend
 * [Unigram](https://github.com/UnigramDev/Unigram) - Telegram for the Windows 10 platform
 * [Deepthought](https://github.com/rubenlagus/Deepthought) - Telegram Client written in Java to support multiple custom implementations
+* [TelegramTUI](https://github.com/bad-day/TelegramTUI) - Telegram client on your console
 
 ## MTProto implementations
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 * [Kotlogram](https://github.com/badoualy/kotlogram) - `Java/Kotlin`
 * [MadelineProto](https://github.com/danog/MadelineProto) - `PHP`
 * [mtproto2json](https://github.com/nikat/mtproto2json) - `Python` MTProto/JSON proxy server
+* [Pyrogram](https://github.com/pyrogram/pyrogram) - `Python` Telegram MTProto API Client Library for Python
 * [telegram-cli](https://github.com/vysheng/tg) - `C` with Lua and Python support
 * [telegram-mtproto](https://github.com/zerobias/telegram-mtproto) - `JavaScript`
 * [telegram-purple](https://github.com/majn/telegram-purple) - `C` libpurple protocol plugin

--- a/README.md
+++ b/README.md
@@ -85,7 +85,11 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 
 ## MTProto Proxy
 * [MTProxy](https://github.com/TelegramMessenger/MTProxy) - Official MTProxy, written in C
+* [MTProtoProxy](https://github.com/TGMTProto/MTProtoProxy) - Unofficial MTProxy, written in C#
 * [mtprotoproxy](https://github.com/alexbers/mtprotoproxy) - Unofficial MTProxy, written in Python
+* [JSMTProxy](https://github.com/FreedomPrevails/JSMTProxy) - Unofficial MTProxy, written in JavaScript
+* [mtproxy](https://github.com/dotcypress/mtproxy) - Unofficial MTProxy, written in Rust
+* [mtg](https://github.com/9seconds/mtg) - Unofficial MTProxy, written in Golang
 * [mtproto_proxy](https://github.com/seriyps/mtproto_proxy) - Unofficial MTProxy, written in Erlang
 
 ## Misc

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Awesome Telegram
+# Awesome Telegram [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 A curated list of [Telegram](https://telegram.org)-related projects and pages in alphabetical order.
 
 - [Awesome Telegram](#awesome-telegram)

--- a/README.md
+++ b/README.md
@@ -20,26 +20,26 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 
 ## Bot Libraries
 
-* [cl-telegram-bot](https://github.com/sovietspaceship/cl-telegram-bot) - Common Lisp
-* [cycle-telegram](https://github.com/goodmind/cycle-telegram) - Cycle.js driver
-* [etelegram](https://github.com/tnt-dev/etelegram) - Erlang
-* [haskell-telegram-api](http://github.com/klappvisor/haskell-telegram-api) - Haskell
-* [libtelegram](https://github.com/slowriot/libtelegram) - C++
-* [morse](https://github.com/Otann/morse) - Clojure
-* [node-telegram-bot-api](https://github.com/yagop/node-telegram-bot-api) - NodeJS
-* [python-telegram-bot](https://github.com/python-telegram-bot/python-telegram-bot) - Python
-* [pyTelegramBotAPI](https://github.com/eternnoir/pyTelegramBotAPI/) - Python
-* [PHP Telegram Bot](https://github.com/php-telegram-bot/core) - PHP
-* [Telebot](https://github.com/KnairdA/Telebot) - Scheme
-* [telegram-bot-ruby](https://github.com/atipugin/telegram-bot-ruby) - Ruby
-* [TelegramBots](https://github.com/rubenlagus/TelegramBots) - Java
-* [TelegraML](https://github.com/nv-vn/TelegraML) - OCaml
-* [x86_64-asm-tgbot](https://github.com/StefanoBelli/x86_64-asm-tgbot) - x86_64 assembly language
-* [SwiftyBot](https://github.com/FabrizioBrancati/SwiftyBot) - Telegram & Facebook Messenger bot with Swift
-* [telegram-bot-swift](https://github.com/zmeyc/telegram-bot-swift) - Telegram Bot SDK for Swift (unofficial)
-* [telegram-bot-rust](https://github.com/telegram-rs/telegram-bot) - Rust Library for creating a Telegram Bot
-* [node-telegram-bot](https://github.com/oott123/node-telegram-bot) - Create your own Telegram bot in minutes with CoffeScript/JS
-* [telebot](https://github.com/yukuku/telebot) - Telegram Bot starter kit
+* [cl-telegram-bot](https://github.com/sovietspaceship/cl-telegram-bot) - `Common Lisp`
+* [cycle-telegram](https://github.com/goodmind/cycle-telegram) - `Typescript` Cycle.js Driver for Telegram Bot API
+* [etelegram](https://github.com/tnt-dev/etelegram) - `Erlang`
+* [haskell-telegram-api](http://github.com/klappvisor/haskell-telegram-api) - `Haskell` High-level bindings to the Telegram Bot API based on servant library
+* [libtelegram](https://github.com/slowriot/libtelegram) - `C++` Fast, efficient, header-only C++ Telegram bot API library using FastCGI
+* [morse](https://github.com/Otann/morse) - `Clojure`
+* [node-telegram-bot-api](https://github.com/yagop/node-telegram-bot-api) - `JavaScript` Telegram Bot API for NodeJS
+* [python-telegram-bot](https://github.com/python-telegram-bot/python-telegram-bot) - `Python` Compatible with Python versions 2.7, 3.3+ and PyPy 
+* [pyTelegramBotAPI](https://github.com/eternnoir/pyTelegramBotAPI/) - `Python` Compatible with Python 2.6, Python 2.7, Python 3.4, Pypy and Pypy 3
+* [PHP Telegram Bot](https://github.com/php-telegram-bot/core) - `PHP` 
+* [Telebot](https://github.com/KnairdA/Telebot) - `Scheme`
+* [telegram-bot-ruby](https://github.com/atipugin/telegram-bot-ruby) - `Ruby`
+* [TelegramBots](https://github.com/rubenlagus/TelegramBots) - `Java`
+* [TelegraML](https://github.com/nv-vn/TelegraML) - `OCaml`
+* [x86_64-asm-tgbot](https://github.com/StefanoBelli/x86_64-asm-tgbot) - `x86_64 assembly`
+* [SwiftyBot](https://github.com/FabrizioBrancati/SwiftyBot) - `Swift` Telegram & Facebook Messenger bot with Swift
+* [telegram-bot-swift](https://github.com/zmeyc/telegram-bot-swift) - `Swift` Telegram Bot SDK for Swift (unofficial)
+* [telegram-bot-rust](https://github.com/telegram-rs/telegram-bot) - `Rust`
+* [node-telegram-bot](https://github.com/oott123/node-telegram-bot) - `CoffeeScript` Create your own Telegram bot in minutes with CoffeScript/JS
+* [telebot](https://github.com/yukuku/telebot) - `Python` Telegram Bot starter kit
 
 ## Clients
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 * [SwiftyBot](https://github.com/FabrizioBrancati/SwiftyBot) - `Swift` Telegram & Facebook Messenger bot with Swift
 * [Telebot](https://github.com/KnairdA/Telebot) - `Scheme`
 * [telebot](https://github.com/yukuku/telebot) - `Python` Telegram Bot starter kit
+* [telebot](https://github.com/tucnak/telebot) - `Go`
 * [TelegramBots](https://github.com/rubenlagus/TelegramBots) - `Java`
 * [TelegraML](https://github.com/nv-vn/TelegraML) - `OCaml`
 * [telegram-bot-ruby](https://github.com/atipugin/telegram-bot-ruby) - `Ruby`

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 
 ## Bot Libraries
 
+* [botstan API](https://github.com/botstan/API) - `PHP` HTTP-based interface created for developers keen on building bots for Telegram
 * [cl-telegram-bot](https://github.com/sovietspaceship/cl-telegram-bot) - `Common Lisp`
 * [cycle-telegram](https://github.com/goodmind/cycle-telegram) - `Typescript` Cycle.js Driver for Telegram Bot API
 * [etelegram](https://github.com/tnt-dev/etelegram) - `Erlang`
@@ -41,7 +42,9 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 * [telegram-bot-rust](https://github.com/telegram-rs/telegram-bot) - `Rust`
 * [telegram-bot-swift](https://github.com/zmeyc/telegram-bot-swift) - `Swift` Telegram Bot SDK for Swift (unofficial)
 * [telegram-node-bot](https://github.com/Naltox/telegram-node-bot) - `JavaScript` Node module for creating Telegram bots
+* [Telegram-PHP](https://github.com/duhow/Telegram-PHP) - `PHP`
 * [telegram.bot](https://github.com/TelegramBots/telegram.bot) - `C#` .NET Client for Telegram Bot API
+* [telepot](https://github.com/nickoala/telepot) - `Python`
 * [x86_64-asm-tgbot](https://github.com/StefanoBelli/x86_64-asm-tgbot) - `x86_64 assembly`
 
 ## Clients

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 * [TelegramTUI](https://github.com/bad-day/TelegramTUI) - Telegram client on your console
 
 ## MTProto implementations
-
+* [Airgram](https://github.com/airgram/airgram) - `TypeScript/JavaScript` modern Telegram Client Framework
 * [Kotlogram](https://github.com/badoualy/kotlogram) - `Java/Kotlin`
 * [MadelineProto](https://github.com/danog/MadelineProto) - `PHP`
 * [mtproto2json](https://github.com/nikat/mtproto2json) - `Python` MTProto/JSON proxy server

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Awesome Telegram
+
 A curated list of [Telegram](https://telegram.org)-related projects and pages in alphabetical order.
+
+Telegram is a messaging app with a focus on speed and security, it’s super-fast, simple and free. You can use Telegram on all your devices at the same time — your messages sync seamlessly across any number of your phones, tablets or computers.
+
+## Contents
 
 - [Awesome Telegram](#awesome-telegram)
   - [API Documentation](#api-documentation)

--- a/README.md
+++ b/README.md
@@ -27,20 +27,20 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 * [libtelegram](https://github.com/slowriot/libtelegram) - `C++` Fast, efficient, header-only C++ Telegram bot API library using FastCGI
 * [morse](https://github.com/Otann/morse) - `Clojure`
 * [node-telegram-bot-api](https://github.com/yagop/node-telegram-bot-api) - `JavaScript` Telegram Bot API for NodeJS
+* [node-telegram-bot](https://github.com/oott123/node-telegram-bot) - `CoffeeScript` Create your own Telegram bot in minutes with CoffeScript/JS
+* [PHP Telegram Bot](https://github.com/php-telegram-bot/core) - `PHP` 
 * [python-telegram-bot](https://github.com/python-telegram-bot/python-telegram-bot) - `Python` Compatible with Python versions 2.7, 3.3+ and PyPy 
 * [pyTelegramBotAPI](https://github.com/eternnoir/pyTelegramBotAPI/) - `Python` Compatible with Python 2.6, Python 2.7, Python 3.4, Pypy and Pypy 3
-* [PHP Telegram Bot](https://github.com/php-telegram-bot/core) - `PHP` 
+* [SwiftyBot](https://github.com/FabrizioBrancati/SwiftyBot) - `Swift` Telegram & Facebook Messenger bot with Swift
 * [Telebot](https://github.com/KnairdA/Telebot) - `Scheme`
-* [telegram-bot-ruby](https://github.com/atipugin/telegram-bot-ruby) - `Ruby`
+* [telebot](https://github.com/yukuku/telebot) - `Python` Telegram Bot starter kit
 * [TelegramBots](https://github.com/rubenlagus/TelegramBots) - `Java`
 * [TelegraML](https://github.com/nv-vn/TelegraML) - `OCaml`
-* [x86_64-asm-tgbot](https://github.com/StefanoBelli/x86_64-asm-tgbot) - `x86_64 assembly`
-* [SwiftyBot](https://github.com/FabrizioBrancati/SwiftyBot) - `Swift` Telegram & Facebook Messenger bot with Swift
-* [telegram-bot-swift](https://github.com/zmeyc/telegram-bot-swift) - `Swift` Telegram Bot SDK for Swift (unofficial)
+* [telegram-bot-ruby](https://github.com/atipugin/telegram-bot-ruby) - `Ruby`
 * [telegram-bot-rust](https://github.com/telegram-rs/telegram-bot) - `Rust`
-* [node-telegram-bot](https://github.com/oott123/node-telegram-bot) - `CoffeeScript` Create your own Telegram bot in minutes with CoffeScript/JS
-* [telebot](https://github.com/yukuku/telebot) - `Python` Telegram Bot starter kit
+* [telegram-bot-swift](https://github.com/zmeyc/telegram-bot-swift) - `Swift` Telegram Bot SDK for Swift (unofficial)
 * [telegram-node-bot](https://github.com/Naltox/telegram-node-bot) - `JavaScript` Node module for creating Telegram bots
+* [x86_64-asm-tgbot](https://github.com/StefanoBelli/x86_64-asm-tgbot) - `x86_64 assembly`
 
 ## Clients
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 
 * [Kotlogram](https://github.com/badoualy/kotlogram) - `Java/Kotlin`
 * [MadelineProto](https://github.com/danog/MadelineProto) - `PHP`
+* [mtproto2json](https://github.com/nikat/mtproto2json) - `Python` MTProto/JSON proxy server
 * [telegram-cli](https://github.com/vysheng/tg) - `C` with Lua and Python support
 * [telegram-mtproto](https://github.com/zerobias/telegram-mtproto) - `JavaScript`
 * [telegram-purple](https://github.com/majn/telegram-purple) - `C` libpurple protocol plugin

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 * [telegram-bot-rust](https://github.com/telegram-rs/telegram-bot) - `Rust`
 * [node-telegram-bot](https://github.com/oott123/node-telegram-bot) - `CoffeeScript` Create your own Telegram bot in minutes with CoffeScript/JS
 * [telebot](https://github.com/yukuku/telebot) - `Python` Telegram Bot starter kit
+* [telegram-node-bot](https://github.com/Naltox/telegram-node-bot) - `JavaScript` Node module for creating Telegram bots
 
 ## Clients
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 * [telegram.bot](https://github.com/TelegramBots/telegram.bot) - `C#` .NET Client for Telegram Bot API
 * [telepot](https://github.com/nickoala/telepot) - `Python`
 * [x86_64-asm-tgbot](https://github.com/StefanoBelli/x86_64-asm-tgbot) - `x86_64 assembly`
-* [TelegramBotAPI](https://github.com/InsanusMokrassar/TelegramBotAPI) - Kotlin bot API library
+* [TelegramBotAPI](https://github.com/InsanusMokrassar/TelegramBotAPI) - `Kotlin` bot API library
 
 ## Clients
 

--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 ## Misc
 
 * [libtgvoip](https://github.com/grishka/libtgvoip) - VoIP library for Telegram clients
+
+## License
+
+[![CC0](http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
   - [Misc](#misc)
 
 ## API Documentation
+
 * [Bot API](https://core.telegram.org/bots/api)
 * [MTProto](https://core.telegram.org/mtproto)
 
@@ -36,6 +37,9 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 * [x86_64-asm-tgbot](https://github.com/StefanoBelli/x86_64-asm-tgbot) - x86_64 assembly language
 * [SwiftyBot](https://github.com/FabrizioBrancati/SwiftyBot) - Telegram & Facebook Messenger bot with Swift
 * [telegram-bot-swift](https://github.com/zmeyc/telegram-bot-swift) - Telegram Bot SDK for Swift (unofficial)
+* [telegram-bot-rust](https://github.com/telegram-rs/telegram-bot) - Rust Library for creating a Telegram Bot
+* [node-telegram-bot](https://github.com/oott123/node-telegram-bot) - Create your own Telegram bot in minutes with CoffeScript/JS
+* [telebot](https://github.com/yukuku/telebot) - Telegram Bot starter kit
 
 ## Clients
 
@@ -50,6 +54,7 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 * [telegram-cli](https://github.com/vysheng/tg) - Command-line client
 * [TReact](https://github.com/goodmind/treact) - ReactJS frontend
 * [Unigram](https://github.com/UnigramDev/Unigram) - Telegram for the Windows 10 platform
+* [Deepthought](https://github.com/rubenlagus/Deepthought) - Telegram Client written in Java to support multiple custom implementations
 
 ## MTProto implementations
 
@@ -63,8 +68,10 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 * [Vail](https://github.com/JuanPotato/Vail) - Rust
 
 ## Schemas
+
 * [Bot API Schema](https://github.com/tranql/telegram-bot-api-schema) - Bot API schema
 * [TL-Schema](https://github.com/stek29/tl-schema) - TL MTProto schema
 
 ## Misc
+
 * [libtgvoip](https://github.com/grishka/libtgvoip) - VoIP library for Telegram clients

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 
 ## MTProto implementations
 
-* [Kotlogram](https://github.com/badoualy/kotlogram) - Kotlin
-* [MadelineProto](https://github.com/danog/MadelineProto) - PHP
-* [telegram-cli](https://github.com/vysheng/tg) - C with Lua and Python support
-* [telegram-mtproto](https://github.com/zerobias/telegram-mtproto) - JavaScript
-* [telegram-purple](https://github.com/majn/telegram-purple) - libpurple protocol plugin
-* [Telethon](https://github.com/LonamiWebs/Telethon) - Python
-* [TL-Elixir](https://gitlab.com/snippets/1664390) - Elixir
-* [Vail](https://github.com/JuanPotato/Vail) - Rust
+* [Kotlogram](https://github.com/badoualy/kotlogram) - `Java/Kotlin`
+* [MadelineProto](https://github.com/danog/MadelineProto) - `PHP`
+* [telegram-cli](https://github.com/vysheng/tg) - `C` with Lua and Python support
+* [telegram-mtproto](https://github.com/zerobias/telegram-mtproto) - `JavaScript`
+* [telegram-purple](https://github.com/majn/telegram-purple) - `C` libpurple protocol plugin
+* [Telethon](https://github.com/LonamiWebs/Telethon) - `Python`
+* [TL-Elixir](https://gitlab.com/snippets/1664390) - `Elixir`
+* [Vail](https://github.com/JuanPotato/Vail) - `Rust`
 
 ## Schemas
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 * [telegram.bot](https://github.com/TelegramBots/telegram.bot) - `C#` .NET Client for Telegram Bot API
 * [telepot](https://github.com/nickoala/telepot) - `Python`
 * [x86_64-asm-tgbot](https://github.com/StefanoBelli/x86_64-asm-tgbot) - `x86_64 assembly`
+* [TelegramBotAPI](https://github.com/InsanusMokrassar/TelegramBotAPI) - Kotlin bot API library
 
 ## Clients
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 ## API Documentation
 
 * [Bot API](https://core.telegram.org/bots/api)
+* [Database library](https://core.telegram.org/tdlib/docs/index.html)
 * [MTProto](https://core.telegram.org/mtproto)
 
 ## Bot Libraries

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
   - [Clients](#clients)
   - [MTProto implementations](#mtproto-implementations)
   - [Schemas](#schemas)
+  - [MTProto Proxy](#mtproto-proxy)
   - [Misc](#misc)
 
 ## API Documentation
@@ -76,6 +77,11 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 
 * [Bot API Schema](https://github.com/tranql/telegram-bot-api-schema) - Bot API schema
 * [TL-Schema](https://github.com/stek29/tl-schema) - TL MTProto schema
+
+## MTProto Proxy
+* [MTProxy](https://github.com/TelegramMessenger/MTProxy) - Official MTProxy, written in C
+* [mtprotoproxy](https://github.com/alexbers/mtprotoproxy) - Unofficial MTProxy, written in Python
+* [mtproto_proxy](https://github.com/seriyps/mtproto_proxy) - Unofficial MTProxy, written in Erlang
 
 ## Misc
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Telegram is a messaging app with a focus on speed and security, it’s super-fas
 * [Telebot](https://github.com/KnairdA/Telebot) - `Scheme`
 * [telebot](https://github.com/yukuku/telebot) - `Python` Telegram Bot starter kit
 * [telebot](https://github.com/tucnak/telebot) - `Go`
+* [TeleDart](https://github.com/DinoLeung/TeleDart) - `Dart` A dart library interfacing with the latest Telegram Bot API.
 * [TelegramBots](https://github.com/rubenlagus/TelegramBots) - `Java`
 * [TelegraML](https://github.com/nv-vn/TelegraML) - `OCaml`
 * [telegram-bot-ruby](https://github.com/atipugin/telegram-bot-ruby) - `Ruby`

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,40 @@
+# Contribution Guidelines
+
+# The pull request should have a useful title. Pull requests with `Update readme.md` as title will be closed right away because I'm so tired of nobody reading this document. Please carefully read everything in `Adding to this list`.
+
+## Table of Contents
+
+- [Adding to this list](#adding-to-this-list)
+- [Creating your own awesome list](#creating-your-own-awesome-list)
+- [Adding something to an awesome list](#adding-something-to-an-awesome-list)
+- [Updating your Pull Request](#updating-your-pull-request)
+
+## Adding to this list
+
+Please ensure your pull request adheres to the following guidelines:
+
+- Search previous suggestions before making a new one, as yours may be a duplicate.
+- Make sure the link is useful before submitting. That implies it has enough content and every item has a good succinct description.
+- Make an individual pull request for each suggestion.
+- Use [title-casing](http://titlecapitalization.com) (AP style).
+- Use the following format: `[Link Name](link)`.
+- Link additions should be added in alphabetical order of the relevant category.
+- New categories or improvements to the existing categorization are welcome.
+- Check your spelling and grammar.
+- Make sure your text editor is set to remove trailing whitespace.
+- The pull request and commit should have a useful title.
+
+Thank you for your suggestions!
+
+## Adding something to an awesome list
+
+If you have something awesome to contribute to an awesome list, this is how you do it.
+
+You'll need a [GitHub account](https://github.com/join)!
+
+1. Access the awesome list's GitHub page. For example: https://github.com/sindresorhus/awesome
+2. Click on the `readme.md` file: ![Step 2 Click on Readme.md](https://cloud.githubusercontent.com/assets/170270/9402920/53a7e3ea-480c-11e5-9d81-aecf64be55eb.png)
+3. Now click on the edit icon. ![Step 3 - Click on Edit](https://cloud.githubusercontent.com/assets/170270/9402927/6506af22-480c-11e5-8c18-7ea823530099.png)
+4. You can start editing the text of the file in the in-browser editor. Make sure you follow guidelines above. You can use [GitHub Flavored Markdown](https://help.github.com/articles/github-flavored-markdown/). ![Step 4 - Edit the file](https://cloud.githubusercontent.com/assets/170270/9402932/7301c3a0-480c-11e5-81f5-7e343b71674f.png)
+5. Say why you're proposing the changes, and then click on "Propose file change". ![Step 5 - Propose Changes](https://cloud.githubusercontent.com/assets/170270/9402937/7dd0652a-480c-11e5-9138-bd14244593d5.png)
+6. Submit the [pull request](https://help.github.com/articles/using-pull-requests/)!


### PR DESCRIPTION
just found out that [https://github.com/alik0211/mtproto-core](https://github.com/alik0211/mtproto-core) is missing from the list. 